### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/fathiyousfi10000/072db9dd-1610-4c93-b25e-4d88ff0508af/5e2a2888-76a5-49c2-b35f-dee096bd8bf8/_apis/work/boardbadge/dafc8974-f023-4e08-ab43-bccbab52b3f2)](https://dev.azure.com/fathiyousfi10000/072db9dd-1610-4c93-b25e-4d88ff0508af/_boards/board/t/5e2a2888-76a5-49c2-b35f-dee096bd8bf8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fathiyousfi10000/072db9dd-1610-4c93-b25e-4d88ff0508af/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.